### PR TITLE
Update draft-jones-perc-dtls-tunnel.md

### DIFF
--- a/draft-jones-perc-dtls-tunnel.md
+++ b/draft-jones-perc-dtls-tunnel.md
@@ -169,15 +169,19 @@ The MDD **MUST** forward all messages received from either the endpoint or the K
 
 ## Key Management Function Tunneling Procedures
 
-The KMF **MUST** be prepared to establish one or more tunnels (DTLS associations) with the MDD for the purpose of relaying DTLS messages between an endpoint and the KMF.  The KMF acts as a server and the MDD acts as a client to establish a tunnel.
+The KMF **MUST** be prepared to establish one or more tunnels (DTLS associations) with an MDD for the purpose of receiving and sending DTLS messages, that will be relayed via a given MDD, with one or more endpoints.  The KMF acts as a server and the MDD acts as a client to establish a tunnel.
 
-When the MDD relays a DTLS message from an endpoint, the MDD will include an association identifier that is unique per endpoint-originated DTLS association and is relayed via the tunnel.  The association identifier remains constant for the life of the DTLS association.  The KMF identifies each distinct endpoint-originated DTLS association by the association identifier and the tunnel over which the DTLS association was established.  The KMF **MUST** use the same association identifier in messages it sends to the endpoint and **MUST** send all messages for a given DTLS association via the same tunnel.  This is to ensure that the MDD can properly relay messages to the correct endpoint.
+When the MDD relays a DTLS message from an endpoint, the MDD will include an association identifier that is unique per endpoint-originated DTLS association and is relayed via the tunnel.  The association identifier remains constant for the life of the DTLS association.  The KMF identifies each distinct endpoint-originated DTLS association by the association identifier and the tunnel over which the DTLS association was established.  
 
-The KMF extracts tunneled DTLS messages and acts on those messages as if the endpoint had established the DTLS association directly with the KMF.  The handling of the messages and certificates is exactly the same as normal DTLS-SRTP procedures between endpoints. 
+The KMF **MUST** encapsulate the DTLS message inside a Tunnel message (see (#tunneling-protocol)) when sending a message to an endpoint.  
 
-When sending a message to the endpoint, the KMF encapsulates the DTLS message inside a Tunnel message (see (#tunneling-protocol)).  At the point the DTLS handshake completes with the endpoint, the KMF will send a DTLS Finished message (perhaps along with other messages) to the endpoint.  As it sends the Finished message, the KMF will also provide key information to the MDD.  This is accomplished by utilizing the Tunnel + Key Info message.  The Key Info includes the selected cipher, MKI [@!RFC3711] value (if any), SRTP master keys, and SRTP master salt values.
+The KMF **MUST** use the same association identifier in messages sent to an endpoint and **MUST** send all messages for a given endpoint DTLS association via the same tunnel.  This ensures MDD operations can forward the messages to the correct endpoint.
 
-Since the KMF acts as the server in the DTLS-SRTP exchanges with the endpoint, it will negotiate with the endpoint which cipher to employ for encryption and authentication.  To ensure successful HBH operations, the ciphers negotiated by the KMF **MUST** be a cipher that is supported by the MDD.
+The KMF extracts tunneled DTLS messages from an endpoint and acts on those messages as if that endpoint had established the DTLS association directly with the KMF, which is acting as the server and the endpoint as the client.  The handling of the messages and certificates is exactly the same as normal DTLS-SRTP procedures between endpoints. 
+
+The KMF **MUST** send a DTLS Finished message to the endpoint at the point the the DTLS handshake completes.  This is accomplished by utilizing the Tunnel + Key Info message.  The Key Info includes the selected cipher (i.e. protection profile), SRTP master keys and SRTP master salt values.
+
+The KMF **MUST** select a cipher that can supported by both the endpoint and the MDD for proper operations.
 
 # Tunneling Protocol
 


### PR DESCRIPTION
Just the KMF Procedures section altered to be both shorter or more consistent with the framing/style used in the MDD procedures.  Also removed ref to MKI in the Key Info message.
